### PR TITLE
Rename upload image to avoid name conflict

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -27,6 +27,7 @@ module.exports.loginUser = async (req, res) => {
           bcrypt.compare(password, user.password, (error, isSame) => {
             if (isSame) {
               req.session.userId = user._id;
+              req.session.username = user.username;
               res.redirect("/");
             } else {
               req.flash("validationError", "Incorrect password");


### PR DESCRIPTION
# Summary
Rename the upload image to avoid upload image from an user replaces upload image of another user.

# What
This is a pull-request for #2, please refer to the issue.

# How
This renames the upload image to the format: `yyyymmddHHMMssfff-username`.

# Screenshots
Before:
![image](https://github.com/user-attachments/assets/8e678225-9772-4b48-a487-48b3120849a5)

After:
![image](https://github.com/user-attachments/assets/cab99fcd-8053-461a-bcd1-e822cf70042b)

